### PR TITLE
add orchagent for debug generate dump

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -109,6 +109,7 @@ orchagent_SOURCES = \
             response_publisher.cpp \
             nvgreorch.cpp \
             zmqorch.cpp \
+            dbggendumporch.cpp\
             dash/dashorch.cpp \
             dash/dashrouteorch.cpp \
             dash/dashvnetorch.cpp \

--- a/orchagent/dbggendumporch.cpp
+++ b/orchagent/dbggendumporch.cpp
@@ -1,0 +1,60 @@
+#include "dbggendumporch.h"
+#include "schema.h"
+
+using namespace std;
+using namespace swss;
+
+DbgGenDumpOrch::DbgGenDumpOrch(TableConnector stateDbConnector):
+        Orch(stateDbConnector.first, stateDbConnector.second),
+        m_stateDbDumpStatsTable(stateDbConnector.first, STATE_DBG_GEN_DUMP_STATS_TABLE_NAME)
+{
+    SWSS_LOG_ENTER();
+}
+
+DbgGenDumpOrch::~DbgGenDumpOrch()
+{
+    SWSS_LOG_ENTER();
+}
+
+void DbgGenDumpOrch::doTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        if (consumer.getTableName() == STATE_DBG_GEN_DUMP_TABLE_NAME)
+        {
+            KeyOpFieldsValuesTuple t = it->second;
+            string op = kfvOp(t);
+            if (op == SET_COMMAND)
+            {
+                auto& fieldValues = kfvFieldsValues(t);
+                auto value = fvValue(fieldValues[0]);
+                const char* value_cstr = value.c_str();
+                SWSS_LOG_INFO("call sai_dbg_generate_dump with file %s\n", value_cstr);
+                sai_status_t ret = sai_dbg_generate_dump(value_cstr);
+                if (ret != SAI_STATUS_SUCCESS)
+                {
+                    SWSS_LOG_ERROR("Failed to generate dbg dump file %s\n", value_cstr);
+                }
+                else
+                {
+                    SWSS_LOG_DEBUG("generate dbg dump file %s successfully\n", value_cstr);
+                }
+
+                //write to state DB the return status to inform the caller
+                string ret_str = std::to_string(ret);
+                string key = kfvKey(t);
+                std::vector<swss::FieldValueTuple> fvTuples;
+                fvTuples.push_back(swss::FieldValueTuple("status", ret_str));
+                m_stateDbDumpStatsTable.set(key, fvTuples);
+            }
+        }
+        consumer.m_toSync.erase(it++);
+    }
+}
+
+
+
+
+

--- a/orchagent/dbggendumporch.h
+++ b/orchagent/dbggendumporch.h
@@ -1,0 +1,30 @@
+#ifndef SWSS_DBG_GEN_DUMP_H
+#define SWSS_DBG_GEN_DUMP_H
+
+#include "orch.h"
+#include "dbconnector.h"
+#include "table.h"
+#include <string>
+
+using namespace std;
+using namespace swss;
+
+extern "C" {
+#include "sai.h"
+}
+
+class DbgGenDumpOrch : public Orch
+{
+public:
+    DbgGenDumpOrch(TableConnector stateDbConnector);
+    
+    ~DbgGenDumpOrch();
+
+    void doTask(Consumer& consumer);
+
+private:
+    Table m_stateDbDumpStatsTable;
+
+};
+
+#endif /* SWSS_DBG_GEN_DUMP_H */

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -766,6 +766,10 @@ bool OrchDaemon::init()
     TwampOrch *twamp_orch = new TwampOrch(confDbTwampTable, stateDbTwampTable, gSwitchOrch, gPortsOrch, vrf_orch);
     m_orchList.push_back(twamp_orch);
 
+    TableConnector stateDbDgbGenDumpTable(m_stateDb, STATE_DBG_GEN_DUMP_TABLE_NAME);
+    auto* gDbgGenDumpOrch = new DbgGenDumpOrch(stateDbDgbGenDumpTable);
+    m_orchList.push_back(gDbgGenDumpOrch);
+
     if (WarmStart::isWarmStart())
     {
         bool suc = warmRestoreAndSyncUp();

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -52,6 +52,7 @@
 #include "dash/dashrouteorch.h"
 #include "dash/dashvnetorch.h"
 #include <sairedis.h>
+#include <dbggendumporch.h>
 
 using namespace swss;
 

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -109,6 +109,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/vxlanorch.cpp \
                 $(top_srcdir)/orchagent/vnetorch.cpp \
                 $(top_srcdir)/orchagent/dtelorch.cpp \
+		$(top_srcdir)/orchagent/dbggendumporch.cpp \
                 $(top_srcdir)/orchagent/flexcounterorch.cpp \
                 $(top_srcdir)/orchagent/watermarkorch.cpp \
                 $(top_srcdir)/orchagent/chassisorch.cpp \


### PR DESCRIPTION
This update introduces support for the sai_dbg_gen_dump API The general process is as follows:
The filename is written to configDB.
This action triggers the dbgGenDumpOrch to write the necessary data to ASIC DB. The syncd process reads from ASIC DB and invokes the SAI. SAI processes the request and returns a response.
syncd writes the response back to redis.
dbgGenDumpOrch retrieves the response and informs the caller by writing to configDB. The caller then removes the data from configDB.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
